### PR TITLE
Fixed hardwareMap name for slide.

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/AutonomousTest.java
@@ -33,7 +33,7 @@ public class AutonomousTest extends LinearOpMode {
 
             Robot robot = new Robot(frontLeft, frontRight, backLeft, backRight);
 
-            slide = hardwareMap.dcMotor.get("slide");
+            slide = hardwareMap.dcMotor.get("Slide");
 
             claw = hardwareMap.servo.get("claw");
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Robot.java
@@ -38,6 +38,7 @@ public class Robot {
     public void DriveForwardDistance(double inches, double power)
     {
         int diameter = 1;
+        double ticksPerRev = frontLeft.getMotorType().getTicksPerRev();
 
         //Rest Encoders.
         frontLeft.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
@@ -48,7 +49,7 @@ public class Robot {
         //Calculate tick value that the motors need to turn.
         double circumference = 3.14*diameter;
         double rotationsNeeded = inches/circumference;
-        int encoderDrivingTarget = (int)(rotationsNeeded*1120);
+        int encoderDrivingTarget = (int)(rotationsNeeded*ticksPerRev);
 
         //Set tick value to the motors' target position.
         frontLeft.setTargetPosition(encoderDrivingTarget);


### PR DESCRIPTION
Changed from `Slide = hardwareMap.dcMotor.get("slide")` to `Slide = hardwareMap.dcMotor.get("Slide")` because there were conflicts in the configuration file when testing.